### PR TITLE
Add missing keys to branch protection rules

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -23,6 +23,9 @@ branches:
         contexts:
           - "Check style"
           - "Lint code"
+      enforce_admins: true
+      required_linear_history: true
+      restrictions: null
 
 labels:
   - name: C-bug


### PR DESCRIPTION
It seems that the branch protection rules require all keys to be set. The missing keys have been added, following the guidelines in the documentation.