### PR TITLE
Require pull requests for default branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -16,8 +16,11 @@ repository:
 branches:
   - name: main
     protection:
-      # Require pull requests, but don't require reviews.
-      required_pull_request_reviews: null
+      required_pull_request_reviews:
+        required_approving_review_count: 0
+        require_code_owner_reviews: true
+        dismiss_stale_reviews: true
+        dismissal_restrictions: {}
       required_status_checks:
         strict: false
         contexts:


### PR DESCRIPTION
Any commit to the default branch must go through a pull request. But given that the project currently only has a single developer, we do not want to enforce reviews. It is unclear if the settings app supports this workflow.